### PR TITLE
maven:3-jdk-8-slim

### DIFF
--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -1,6 +1,6 @@
 FROM jenkins/jnlp-slave:alpine as jnlp
 
-FROM maven:alpine
+FROM maven:3-jdk-8-slim
 
 COPY --from=jnlp /usr/local/bin/jenkins-slave /usr/local/bin/jenkins-agent
 COPY --from=jnlp /usr/share/jenkins/slave.jar /usr/share/jenkins/slave.jar


### PR DESCRIPTION
The currently specified tag [no longer exists](https://hub.docker.com/_/maven) as of https://github.com/carlossg/docker-maven/commit/6251fd3dfc1a3ec50c7c38a112acc5d6b3579dc5 / https://github.com/docker-library/openjdk/pull/322.