### PR TITLE
Install Git

### DIFF
--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -2,6 +2,10 @@ FROM jenkins/jnlp-slave:alpine as jnlp
 
 FROM maven:3-jdk-8-slim
 
+RUN apt-get update && \
+    apt-get install -y \
+        git
+
 COPY --from=jnlp /usr/local/bin/jenkins-slave /usr/local/bin/jenkins-agent
 COPY --from=jnlp /usr/share/jenkins/slave.jar /usr/share/jenkins/slave.jar
 


### PR DESCRIPTION
Pretty common for builds to need to do Git CLI operations from `sh` steps, though you might not immediately notice this on ci.jenkins.io since it seems to be configured to use JGit by default so `git` / `checkout` steps would succeed without it.

The installation also pulls in `ssh` and `perl` commands which are likely to be helpful in some projects.

I was afraid I had regressed this in #2 (as in https://github.com/carlossg/docker-maven/issues/110#issuecomment-497693840 for example) but I checked and actually `git` was not available before that, either.

If this gets merged, what is the timeline for it to be live on ci.jenkins.io? Is that automatic, or is there some additional deployment step that needs to happen?