### PR TITLE
 Install libfreetype & libfontconfig since JFreeChart require them

### DIFF
--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -4,7 +4,9 @@ FROM maven:3-jdk-8-slim
 
 RUN apt-get update && \
     apt-get install -y \
-        git
+        git \
+        libfontconfig1 \
+        libfreetype6
 
 COPY --from=jnlp /usr/local/bin/jenkins-slave /usr/local/bin/jenkins-agent
 COPY --from=jnlp /usr/share/jenkins/slave.jar /usr/share/jenkins/slave.jar

--- a/maven/Dockerfile.jdk11
+++ b/maven/Dockerfile.jdk11
@@ -2,6 +2,10 @@ FROM jenkins/jnlp-slave:alpine as jnlp
 
 FROM maven:3-jdk-11-slim
 
+RUN apt-get update && \
+    apt-get install -y \
+        git
+
 COPY --from=jnlp /usr/local/bin/jenkins-slave /usr/local/bin/jenkins-agent
 COPY --from=jnlp /usr/share/jenkins/slave.jar /usr/share/jenkins/slave.jar
 

--- a/maven/Dockerfile.jdk11
+++ b/maven/Dockerfile.jdk11
@@ -4,7 +4,9 @@ FROM maven:3-jdk-11-slim
 
 RUN apt-get update && \
     apt-get install -y \
-        git
+        git \
+        libfontconfig1 \
+        libfreetype6
 
 COPY --from=jnlp /usr/local/bin/jenkins-slave /usr/local/bin/jenkins-agent
 COPY --from=jnlp /usr/share/jenkins/slave.jar /usr/share/jenkins/slave.jar


### PR DESCRIPTION
Subsumes #4. Analogous to https://github.com/jenkinsci/docker/pull/837. Required for https://github.com/jenkinsci/jenkins/pull/4129. Testing protocol:

```sh
docker build -t testing -f maven/Dockerfile maven
docker run -v ~/.m2:/var/maven/.m2 --rm --name mvn -u $(id -u):$(id -g) -e MAVEN_CONFIG=/var/maven/.m2 -v /…/jenkinsci/jenkins:/usr/src/mymaven -w /usr/src/mymaven --entrypoint mvn testing -Duser.home=/var/maven -f core -Dtest=LoadStatisticsTest\#graph surefire:test
```

@slide @rtyler