### PR TITLE
Upgrade to Maven 3.6.2

### DIFF
--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -1,6 +1,6 @@
 FROM jenkins/jnlp-slave:alpine as jnlp
 
-FROM maven:3-jdk-8-slim
+FROM maven:3.6.2-jdk-8-slim
 
 RUN apt-get update && \
     apt-get install -y \

--- a/maven/Dockerfile.jdk11
+++ b/maven/Dockerfile.jdk11
@@ -1,6 +1,6 @@
 FROM jenkins/jnlp-slave:alpine as jnlp
 
-FROM maven:3-jdk-11-slim
+FROM maven:3.6.2-jdk-11-slim
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
As of https://github.com/carlossg/docker-maven/pull/123 we can use [these tags](https://hub.docker.com/_/maven?tab=tags). It is wise to use specific tags, as otherwise you are at the mercy of whatever version the builder machine last pulled. Also, if merged, this would I guess force an update to be published where otherwise it might not be.

#6 should be similarly adjusted.