### PR TITLE
change slave to agent

### DIFF
--- a/maven/Dockerfile
+++ b/maven/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
         libfontconfig1 \
         libfreetype6
 
-COPY --from=jnlp /usr/local/bin/jenkins-slave /usr/local/bin/jenkins-agent
-COPY --from=jnlp /usr/share/jenkins/slave.jar /usr/share/jenkins/slave.jar
+COPY --from=jnlp /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-agent
+COPY --from=jnlp /usr/share/jenkins/agent.jar /usr/share/jenkins/agent.jar
 
 ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/maven/Dockerfile.jdk11
+++ b/maven/Dockerfile.jdk11
@@ -8,7 +8,7 @@ RUN apt-get update && \
         libfontconfig1 \
         libfreetype6
 
-COPY --from=jnlp /usr/local/bin/jenkins-slave /usr/local/bin/jenkins-agent
-COPY --from=jnlp /usr/share/jenkins/slave.jar /usr/share/jenkins/slave.jar
+COPY --from=jnlp /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-agent
+COPY --from=jnlp /usr/share/jenkins/agent.jar /usr/share/jenkins/agent.jar
 
 ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -4,7 +4,7 @@ FROM node:alpine
 
 RUN apk -U add openjdk8-jre
 
-COPY --from=jnlp /usr/local/bin/jenkins-slave /usr/local/bin/jenkins-agent
-COPY --from=jnlp /usr/share/jenkins/slave.jar /usr/share/jenkins/slave.jar
+COPY --from=jnlp /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-agent
+COPY --from=jnlp /usr/share/jenkins/agent.jar /usr/share/jenkins/agent.jar
 
 ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -4,7 +4,7 @@ FROM python:alpine
 
 RUN apk -U add openjdk8-jre
 
-COPY --from=jnlp /usr/local/bin/jenkins-slave /usr/local/bin/jenkins-agent
-COPY --from=jnlp /usr/share/jenkins/slave.jar /usr/share/jenkins/slave.jar
+COPY --from=jnlp /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-agent
+COPY --from=jnlp /usr/share/jenkins/agent.jar /usr/share/jenkins/agent.jar
 
 ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/python/Dockerfile.python2
+++ b/python/Dockerfile.python2
@@ -4,7 +4,7 @@ FROM python:2-alpine
 
 RUN apk -U add openjdk8-jre
 
-COPY --from=jnlp /usr/local/bin/jenkins-slave /usr/local/bin/jenkins-agent
-COPY --from=jnlp /usr/share/jenkins/slave.jar /usr/share/jenkins/slave.jar
+COPY --from=jnlp /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-agent
+COPY --from=jnlp /usr/share/jenkins/agent.jar /usr/share/jenkins/agent.jar
 
 ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -qq && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=jnlp /usr/local/bin/jenkins-slave /usr/local/bin/jenkins-agent
-COPY --from=jnlp /usr/share/jenkins/slave.jar /usr/share/jenkins/slave.jar
+COPY --from=jnlp /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-agent
+COPY --from=jnlp /usr/share/jenkins/agent.jar /usr/share/jenkins/agent.jar
 
 ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -4,7 +4,7 @@ FROM hashicorp/terraform:light
 
 RUN apk -U add openjdk8-jre
 
-COPY --from=jnlp /usr/local/bin/jenkins-slave /usr/local/bin/jenkins-agent
-COPY --from=jnlp /usr/share/jenkins/slave.jar /usr/share/jenkins/slave.jar
+COPY --from=jnlp /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-agent
+COPY --from=jnlp /usr/share/jenkins/agent.jar /usr/share/jenkins/agent.jar
 
 ENTRYPOINT ["/usr/local/bin/jenkins-agent"]


### PR DESCRIPTION
Since this change, the docker copy instruction fails to follow the symlink and to the following error
```
root@5fdfa5f289c3:/# /usr/local/bin/jenkins-agent 
Warning: JnlpProtocol3 is disabled by default, use JNLP_PROTOCOL_OPTS to alter the behavior
Error: Could not find or load main class hudson.remoting.jnlp.Main
Caused by: java.lang.ClassNotFoundException: hudson.remoting.jnlp.Main
root@5fdfa5f289c3:/# /usr/local/bin/jenkins-agent 
```
