### PR TITLE
Added dotnetcore sdk agent

### DIFF
--- a/coresdk/31/Dockerfile
+++ b/coresdk/31/Dockerfile
@@ -1,0 +1,12 @@
+FROM jenkins/inbound-agent:alpine as jnlp
+
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine
+
+RUN apk -U add openjdk8-jre git openssh && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm /var/cache/apk/*
+
+COPY --from=jnlp /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-agent
+COPY --from=jnlp /usr/share/jenkins/agent.jar /usr/share/jenkins/agent.jar
+
+ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/coresdk/31/Makefile
+++ b/coresdk/31/Makefile
@@ -1,0 +1,2 @@
+SUFFIX=coreruntime:3.1
+include ../../common.mk

--- a/coresdk/31/Makefile
+++ b/coresdk/31/Makefile
@@ -1,2 +1,2 @@
-SUFFIX=coreruntime:3.1
+SUFFIX=coresdk:3.1
 include ../../common.mk


### PR DESCRIPTION
I am creating this pull request because the coreruntime image we created from the dockerfile did not work for us when used as the image for one of our container templates.  When using the coreruntime image we received the following errors:
> 1. no file or directory for dotnet
> 2. scm was not able to complete due to git and ssh not being present in the image

For reference, we are trying create container templates to be used with the [kubernetes-plugin](https://github.com/jenkinsci/kubernetes-plugin)

If I am using the coreruntime image or the container/pod template incorrectly please let me know. I followed the plugin documentation to configure the template and the pipeline.