### PR TITLE
Fix issue when Build occurs on different node than Publish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,11 @@ pipeline {
     }
 
     stages { 
-        stage('Build') {
+        stage('Build Only') {
+            when {
+                expression { !infra.isTrusted() }
+            }
+
             parallel {
                 stage('Windows') {
                     agent {
@@ -33,7 +37,7 @@ pipeline {
             }
         }
 
-        stage('Publish') {
+        stage('Build and Publish') {
             when {
                 expression { infra.isTrusted() }
             }

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build:
 		$(MAKE) -C $$name GROUP=$(GROUP) PREFIX=$(PREFIX) SUFFIX=$$name; \
 	done;
 
-push:
+push: build
 	set -e; \
 	for d in $$(find . -name Dockerfile -type f); do \
 		name=$$(echo $$(dirname $$d) | cut -b 3- ); \


### PR DESCRIPTION
The Jenkinsfile currently has the build and publish stages separate, which means they could run on different nodes. This means that the build portion may occur on one node and then push on another, which won't work, the tags won't be available to push. This updates it so that the 'Build Only' stage, which is used for CI purposes will be run on non-trusted and the 'Build + Push' will be run on trusted. It also makes the push target in the makefile dependent on the build target to make sure the build happens when push is used as the target. If the images are already built and tagged, this won't cause that much latency to complete, since everything will already be cached.