### PR TITLE
Fix: Make Push depend on Build

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -34,6 +34,7 @@ function Build() {
 }
 
 function Push() {
+	Build()
 	Get-ChildItem -Include "Dockerfile.windows*" -File -Recurse | Split-Path -Parent | Get-Unique | ForEach-Object {
 		Push-Location $_
 		try {

--- a/make.ps1
+++ b/make.ps1
@@ -34,7 +34,7 @@ function Build() {
 }
 
 function Push() {
-	Build()
+	Build
 	Get-ChildItem -Include "Dockerfile.windows*" -File -Recurse | Split-Path -Parent | Get-Unique | ForEach-Object {
 		Push-Location $_
 		try {


### PR DESCRIPTION
Fix the similar issue that was in the Makefile where the Build could happen on a different node than Push