### PR TITLE
Fix: Make Push depend on Build

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -34,6 +34,7 @@ function Build() {
 }
 
 function Push() {
+	Build
 	Get-ChildItem -Include "Dockerfile.windows*" -File -Recurse | Split-Path -Parent | Get-Unique | ForEach-Object {
 		Push-Location $_
 		try {


### PR DESCRIPTION
Fix similar to what was done for Makefile to make Push depend on Build in the case where the Build and Push could have run on separate nodes.