### PR TITLE
add coresdk 5.0

### DIFF
--- a/coresdk/50/Dockerfile
+++ b/coresdk/50/Dockerfile
@@ -1,0 +1,12 @@
+FROM jenkins/inbound-agent:alpine as jnlp
+
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine
+
+RUN apk -U add openjdk8-jre git openssh && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm /var/cache/apk/*
+
+COPY --from=jnlp /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-agent
+COPY --from=jnlp /usr/share/jenkins/agent.jar /usr/share/jenkins/agent.jar
+
+ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/coresdk/50/Makefile
+++ b/coresdk/50/Makefile
@@ -1,0 +1,3 @@
+override SUFFIX:=coresdk:5.0
+override IMAGE_TAR=coresdk5.0-image.tar
+include ../../common.mk


### PR DESCRIPTION
Added coresdk 5.0, to allow building of .NET 5.0 applications.
I did this by copying coresdk 3.1 to 5.0.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

I don't think this has a relevant issue, pull request or that tests are required.