### PR TITLE
[chore] Add `--input` parameter so `docker load` works

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -34,7 +34,7 @@ clean:
 	rm -f *.tar
 
 push: build
-	docker load $(IMAGE_TAR)
+	docker load --input $(IMAGE_TAR)
 	docker push $(NAME)
 
 .PHONY: lint build test push clean


### PR DESCRIPTION
To load an image from a tar archive, you need to pass `--input` before the archive filename. See https://docs.docker.com/engine/reference/commandline/load/#options

- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
