### PR TITLE
Use newer image for maven on windows (currently 3.8.1)

### DIFF
--- a/maven/Dockerfile.windows
+++ b/maven/Dockerfile.windows
@@ -1,5 +1,5 @@
 # escape=`
-FROM csanchez/maven:3-jdk-8-windowsservercore-1809 as maven
+FROM csanchez/maven:3-openjdk-8-windowsservercore-1809 as maven
 
 FROM jenkins/inbound-agent:windowsservercore-1809
 

--- a/maven/Dockerfile.windows-jdk11
+++ b/maven/Dockerfile.windows-jdk11
@@ -1,5 +1,5 @@
 # escape=`
-FROM csanchez/maven:3-jdk-11-windowsservercore-1809 as maven
+FROM csanchez/maven:3-openjdk-11-windowsservercore-1809 as maven
 
 FROM jenkins/inbound-agent:jdk11-windowsservercore-1809
 


### PR DESCRIPTION
https://github.com/jenkinsci/plugin-pom/pull/419#issuecomment-882796440

cc @jglick @dduportal 

previous image hasn't been updated in a year, looks like vendor specific images were added