### PR TITLE
fix: replace 'windock' label by 'docker-windows' (INFRA-3099)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
             parallel {
                 stage('Windows') {
                     agent {
-                        label "windock"
+                        label "docker-windows"
                     }
                     steps {
                         bat "powershell -File ./make.ps1 -Target build"
@@ -48,7 +48,7 @@ pipeline {
             parallel {
                 stage('Windows') {
                     agent {
-                        label "windock"
+                        label "docker-windows"
                     }
                     steps {
                         withCredentials([[$class: 'ZipFileBinding',


### PR DESCRIPTION
Following https://github.com/jenkins-infra/jenkins-infra/pull/1936, replace 'windock' label by 'docker-windows'
See https://issues.jenkins.io/browse/INFRA-3099?focusedCommentId=414936

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
