### PR TITLE
Add git to node alpine image

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -2,7 +2,7 @@ FROM jenkins/inbound-agent:alpine as jnlp
 
 FROM node:alpine
 
-RUN apk -U add openjdk8-jre
+RUN apk -U add openjdk8-jre git
 
 COPY --from=jnlp /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-agent
 COPY --from=jnlp /usr/share/jenkins/agent.jar /usr/share/jenkins/agent.jar


### PR DESCRIPTION
Similar to how the maven debian image installs the git binary, the node image (and possibly others) should have the git binary aswell so that jenkins can checkout source when running this image. Otherwise exceptions like the following can occur:

Caused by: java.io.IOException: Cannot run program "git" (in directory "/home/jenkins/agent/workspace/Blablabla_PR-268"): error=2, No such file or directory
