### PR TITLE
Docker agent automatically track latest versions of docker cli, compose, and buildx.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ USER root
 RUN apk add --no-cache -u libcurl curl
 
 # Install Docker client, Docker compose, and buildx
-RUN curl -s https://download.docker.com/linux/static/stable/x86_64/ | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | sort -t . -k 1,1n -k 2,2n -k 3,3n | tail -n 1 > /tmp/docker_version \
+RUN curl -s https://download.docker.com/linux/static/stable/`uname -m`/ | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | sort -t . -k 1,1n -k 2,2n -k 3,3n | tail -n 1 > /tmp/docker_version \
     && curl -fsSL https://download.docker.com/linux/static/stable/`uname -m`/docker-`cat /tmp/docker_version`.tgz | tar --strip-components=1 -xz -C /usr/local/bin docker/docker \
     && rm /tmp/docker_version
 RUN curl -s -I https://github.com/docker/compose/releases/latest | awk -F '/' '/^location/ {print substr($NF, 1, length($NF)-1)}'  > /tmp/compose_version \
@@ -19,7 +19,7 @@ RUN curl -s -I https://github.com/docker/compose/releases/latest | awk -F '/' '/
 RUN uname -m > /tmp/arch \
     && sed -i 's/x86_64/amd64/g' /tmp/arch \
     && curl -s -I https://github.com/docker/buildx/releases/latest | awk -F '/' '/^location/ {print substr($NF, 1, length($NF)-1)}' > /tmp/buildx_version \
-    && curl -fsSL https://github.com/docker/buildx/releases/download/`cat /tmp/buildx_version`/buildx-`cat /tmp/buildx_version`.linux-`cat /tmp/arch` > /usr/libexec/docker/cli-plugins/docker-buildx \
+    && curl -fsSL https://github.com/docker/buildx/releases/download/`cat /tmp/buildx_version`/buildx-`cat /tmp/buildx_version`.`uname -s`-`cat /tmp/arch` > /usr/libexec/docker/cli-plugins/docker-buildx \
     && chmod +x /usr/libexec/docker/cli-plugins/docker-buildx \
     && docker buildx install \
     && rm /tmp/arch /tmp/buildx_version

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,12 +4,25 @@ USER root
 
 # Alpine seems to come with libcurl baked in, which is prone to mismatching
 # with newer versions of curl. The solution is to upgrade libcurl.
-RUN apk update && apk add -u libcurl curl
-# Install Docker client
-ARG DOCKER_VERSION=24.0.6
-ARG DOCKER_COMPOSE_VERSION=1.21.0
-RUN curl -fsSL https://download.docker.com/linux/static/stable/`uname -m`/docker-$DOCKER_VERSION.tgz | tar --strip-components=1 -xz -C /usr/local/bin docker/docker
-RUN curl -fsSL https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose
+RUN apk add --no-cache -u libcurl curl
+
+# Install Docker client, Docker compose, and buildx
+RUN curl -s https://download.docker.com/linux/static/stable/x86_64/ | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | sort -t . -k 1,1n -k 2,2n -k 3,3n | tail -n 1 > /tmp/docker_version \
+    && curl -fsSL https://download.docker.com/linux/static/stable/`uname -m`/docker-`cat /tmp/docker_version`.tgz | tar --strip-components=1 -xz -C /usr/local/bin docker/docker \
+    && rm /tmp/docker_version
+RUN curl -s -I https://github.com/docker/compose/releases/latest | awk -F '/' '/^location/ {print substr($NF, 1, length($NF)-1)}'  > /tmp/compose_version \
+    && mkdir -p /usr/libexec/docker/cli-plugins/ \
+    && curl -fsSL https://github.com/docker/compose/releases/download/`cat /tmp/compose_version`/docker-compose-`uname -s`-`uname -m` > /usr/libexec/docker/cli-plugins/docker-compose \
+    && chmod +x /usr/libexec/docker/cli-plugins/docker-compose \
+    && rm /tmp/compose_version
+## buildx is released as amd64, and uname calls it x86_64
+RUN uname -m > /tmp/arch \
+    && sed -i 's/x86_64/amd64/g' /tmp/arch \
+    && curl -s -I https://github.com/docker/buildx/releases/latest | awk -F '/' '/^location/ {print substr($NF, 1, length($NF)-1)}' > /tmp/buildx_version \
+    && curl -fsSL https://github.com/docker/buildx/releases/download/`cat /tmp/buildx_version`/buildx-`cat /tmp/buildx_version`.linux-`cat /tmp/arch` > /usr/libexec/docker/cli-plugins/docker-buildx \
+    && chmod +x /usr/libexec/docker/cli-plugins/docker-buildx \
+    && docker buildx install \
+    && rm /tmp/arch /tmp/buildx_version
 
 RUN touch /debug-flag
 USER jenkins


### PR DESCRIPTION
Automatically track the latest official releases of Docker, Docker compose, and Docker build. It assumes these packages follow the current naming conventions (below) in their new releases.

Naming conventions:
```text
https://download.docker.com/linux/static/stable/$ARCH/docker-X.Y.Z.tgz
https://github.com/docker/compose/releases/download/$TAG/docker-compose-$SYSTEM-$ARCH
https://github.com/docker/buildx/releases/download/$TAG/buildx-$TAG.$SYSTEM-$ARCH
```

This commit fixes [the comment](https://github.com/jenkinsci/docker-inbound-agents/pull/40#issuecomment-1794109595) under PR #40 , and also closes PR #41 .

### Testing done

```sh
docker build -t jenkins-docker-agent:latest -f docker/Dockerfile .
docker run -it jenkins-docker-agent:latest /bin/sh
```
and then inside the container:
```sh
~ $ docker compose version
Docker Compose version v2.23.0
~ $ docker buildx version
github.com/docker/buildx v0.11.2 9872040b6626fb7d87ef7296fd5b832e8cc2ad17
```

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
