### PR TITLE
fix(docker): Use the latest alpine jdk8 image

### DIFF
--- a/maven/jdk8/Dockerfile
+++ b/maven/jdk8/Dockerfile
@@ -1,6 +1,6 @@
-FROM jenkins/inbound-agent:alpine as jnlp
+FROM jenkins/inbound-agent:latest-alpine-jdk8 AS jnlp
 
-FROM maven:3.6.3-jdk-8-slim
+FROM maven:3.8.6-jdk-8-slim
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
Update `maven/jdk8/Dockerfile` to use JDK8-based inbound agent image.
Fixes #46.

* Change the first stage base image from `jenkins/inbound-agent:alpine` to `jenkins/inbound-agent:latest-alpine-jdk8`
* Change the second stage base image from `maven:3.6.3-jdk-8-slim` to `maven:3.8.6-jdk-8-slim`.

### Testing done

`make && docker run -ti --rm jenkins/jnlp-agent-jdk8:latest`

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
